### PR TITLE
build: avoid `--workspace` build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -153,8 +153,6 @@
 
         targets.wasm32-wasi = false;
 
-        build.workspace = true;
-
         clippy.allTargets = true;
         clippy.deny = ["warnings"];
         clippy.workspace = true;


### PR DESCRIPTION
This is not necessary and complicates downstream usage