### PR TITLE
feat!: allow specifying a path to `lock!` macro, add `lock_sync!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+<!---
+ ## [0.2.0] - 2023-04-10
+-->
+
+### Added
+
+- Functionality to specify a path to `wit` directory in `lock!`
+- `lock_sync!` macro executing `lock!` in a multi-threaded Tokio context. This macro is guarded by `sync` feature, which is enabled by default
+
+## [0.1.0] - 2023-04-07
+
+### Added
+
+- Initial `depit` library and binary implementations
+
+[unreleased]: https://github.com/rvolosatovs/depit/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/rvolosatovs/depit/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,7 +671,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "depit",
- "tokio",
  "wit-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,6 @@ tokio-util = { workspace = true, features = ["compat"] }
 toml = { workspace = true, features = ["display", "parse"] }
 tracing-subscriber = { workspace = true, features = ["ansi", "env-filter", "fmt", "json", "std"] }
 
-[build-dependencies]
-anyhow = { workspace = true, features = ["std"] }
-depit = { workspace = true }
-tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread"] }
-
 [dev-dependencies]
 github-build = { workspace = true }
 wit-bindgen = { workspace = true, features = ["default"] }

--- a/crates/depit/Cargo.toml
+++ b/crates/depit/Cargo.toml
@@ -27,6 +27,12 @@ toml = { workspace = true, features = ["display", "parse", "preserve_order"] }
 tracing = { workspace = true, features = ["attributes"] }
 url = { workspace = true, features = ["serde"] }
 
+[features]
+default = ["sync"]
+sync = [
+    "tokio/rt-multi-thread"
+]
+
 [target.'cfg(windows)'.dependencies]
 # Required for https://github.com/dignifiedquire/async-tar/pull/35
 async-std = { workspace = true, features = ["unstable"] }

--- a/src/bin/depit/main.rs
+++ b/src/bin/depit/main.rs
@@ -1,10 +1,11 @@
 #![warn(clippy::pedantic)]
 
+use std::path::PathBuf;
+
 use anyhow::Context;
-use camino::{Utf8Path, Utf8PathBuf};
 use clap::{Parser, Subcommand};
 use depit::Identifier;
-use tokio::fs::{self, File};
+use tokio::fs::File;
 use tokio::io;
 use tokio_util::compat::TokioAsyncWriteCompatExt;
 use tracing_subscriber::prelude::*;
@@ -14,15 +15,15 @@ use tracing_subscriber::prelude::*;
 struct Cli {
     /// Dependency output directory
     #[arg(short, long, default_value = "wit/deps")]
-    deps: Utf8PathBuf,
+    deps: PathBuf,
 
     /// Dependency manifest path
     #[arg(short, long, default_value = "wit/deps.toml")]
-    manifest: Utf8PathBuf,
+    manifest: PathBuf,
 
     /// Dependency lock path
     #[arg(short, long, default_value = "wit/deps.lock")]
-    lock: Utf8PathBuf,
+    lock: PathBuf,
 
     #[command(subcommand)]
     command: Option<Command>,
@@ -43,27 +44,8 @@ enum Command {
 
         /// Optional output path, if not specified, the archive will be written to stdout
         #[arg(short, long)]
-        output: Option<Utf8PathBuf>,
+        output: Option<PathBuf>,
     },
-}
-
-async fn lock(
-    manifest_path: impl AsRef<Utf8Path>,
-    lock_path: impl AsRef<Utf8Path>,
-    deps_path: impl AsRef<Utf8Path>,
-    packages: impl IntoIterator<Item = &Identifier>,
-) -> anyhow::Result<()> {
-    let manifest_path = manifest_path.as_ref();
-    let lock_path = lock_path.as_ref();
-    let deps_path = deps_path.as_ref();
-
-    let manifest = fs::read_to_string(&manifest_path)
-        .await
-        .with_context(|| format!("failed to read manifest at `{manifest_path}`"))?;
-    depit::lock_path(manifest, lock_path, deps_path, packages)
-        .await
-        .context("failed to lock dependencies")?;
-    Ok(())
 }
 
 #[tokio::main]
@@ -92,17 +74,23 @@ async fn main() -> anyhow::Result<()> {
     } = Cli::parse();
 
     match command {
-        None => lock(manifest_path, lock_path, deps_path, None).await,
+        None => depit::lock_path(manifest_path, lock_path, deps_path, None)
+            .await
+            .map(|_| ()),
         Some(Command::Lock { package }) => {
-            lock(manifest_path, lock_path, deps_path, &package).await
+            depit::lock_path(manifest_path, lock_path, deps_path, &package)
+                .await
+                .map(|_| ())
         }
         Some(Command::Tar { package, output }) => {
-            lock(manifest_path, lock_path, &deps_path, [&package]).await?;
+            depit::lock_path(manifest_path, lock_path, &deps_path, [&package])
+                .await
+                .map(|_| ())?;
             let package = deps_path.join(package);
             if let Some(output) = output {
-                let output = File::create(&output)
-                    .await
-                    .with_context(|| format!("failed to create output path `{output}`"))?;
+                let output = File::create(&output).await.with_context(|| {
+                    format!("failed to create output path `{}`", output.display())
+                })?;
                 depit::tar(package, output.compat_write()).await?;
             } else {
                 depit::tar(package, io::stdout().compat_write()).await?;

--- a/tests/github-build/Cargo.toml
+++ b/tests/github-build/Cargo.toml
@@ -15,4 +15,3 @@ wit-bindgen = { workspace = true, features = ["default"] }
 [build-dependencies]
 anyhow = { workspace = true, features = ["std"] }
 depit = { workspace = true }
-tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread"] }

--- a/tests/github-build/build.rs
+++ b/tests/github-build/build.rs
@@ -6,6 +6,10 @@ async fn main() -> anyhow::Result<()> {
         .await
         .context("failed to lock WIT dependencies")?;
 
+    depit::lock!("wit")
+        .await
+        .context("failed to lock WIT dependencies")?;
+
     println!("cargo:rerun-if-changed=wit/deps");
     println!("cargo:rerun-if-changed=wit/deps.lock");
     println!("cargo:rerun-if-changed=wit/deps.toml");

--- a/tests/github-build/build.rs
+++ b/tests/github-build/build.rs
@@ -1,14 +1,8 @@
 use anyhow::Context;
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    depit::lock!()
-        .await
-        .context("failed to lock WIT dependencies")?;
-
-    depit::lock!("wit")
-        .await
-        .context("failed to lock WIT dependencies")?;
+fn main() -> anyhow::Result<()> {
+    depit::lock_sync!().context("failed to lock WIT dependencies")?;
+    depit::lock_sync!("wit").context("failed to lock WIT dependencies")?;
 
     println!("cargo:rerun-if-changed=wit/deps");
     println!("cargo:rerun-if-changed=wit/deps.lock");


### PR DESCRIPTION
`depit::lock_path` function now takes the manifest by path, which is a breaking change