### PR TITLE
feat: add `depit update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2023-04-11
+
+### Added
+
+- `depit update` along with the `depit::update_path` and `depit::update` library API
+
 ## [0.2.1] - 2023-04-10
 
 ### Fixed
@@ -27,7 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial `depit` library and binary implementations
 
-[unreleased]: https://github.com/rvolosatovs/depit/compare/v0.2.1...HEAD
-[0.2.1]: https://github.com/rvolosatovs/depit/releases/tag/v0.2.0
+[unreleased]: https://github.com/rvolosatovs/depit/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/rvolosatovs/depit/releases/tag/v0.2.2
+[0.2.1]: https://github.com/rvolosatovs/depit/releases/tag/v0.2.1
 [0.2.0]: https://github.com/rvolosatovs/depit/releases/tag/v0.2.0
 [0.1.0]: https://github.com/rvolosatovs/depit/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "depit"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "depit-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "build-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "depit-cli"
-version = "0.2.1"
+version = "0.2.2"
 description = "WIT dependency manager"
 
 authors.workspace = true

--- a/crates/depit/Cargo.toml
+++ b/crates/depit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "depit"
-version = "0.2.1"
+version = "0.2.2"
 description = "WIT dependency management"
 readme = "../../README.md"
 

--- a/crates/depit/src/manifest.rs
+++ b/crates/depit/src/manifest.rs
@@ -2,7 +2,6 @@ use crate::{
     copy_wits, untar, Cache, Digest, DigestReader, Identifier, Lock, LockEntry, LockEntrySource,
 };
 
-use core::borrow::Borrow;
 use core::convert::identity;
 use core::fmt;
 use core::ops::Deref;
@@ -352,13 +351,12 @@ impl Manifest {
         self,
         at: Option<impl AsRef<Path>>,
         deps: impl AsRef<Path>,
-        lock: Option<impl Borrow<Lock>>,
+        lock: Option<&Lock>,
         cache: Option<&impl Cache>,
         packages: impl IntoIterator<Item = &Identifier>,
     ) -> anyhow::Result<Lock> {
         let at = at.as_ref();
         let deps = deps.as_ref();
-        let lock = lock.as_ref().map(Borrow::borrow);
         let packages: HashSet<_> = packages.into_iter().collect();
         if let Some(id) = packages.iter().find(|id| !self.contains_key(**id)) {
             bail!("selected package `{id}` not found in manifest")

--- a/examples/github/wit/deps.lock
+++ b/examples/github/wit/deps.lock
@@ -1,7 +1,7 @@
 [http]
-url = "https://github.com/WebAssembly/wasi-http/archive/6c6855a7329fb040a48ecdbad1765be8e694416c.tar.gz"
-sha256 = "1667921c63364722b0d23eb69023ede0cdace86ee9b4c6f7c4286b3a2dd8d635"
-sha512 = "9b2f225411d347d3e99276359d3ad98475e9fbee4b3fad0169060dc648a5efa3584a6a1db990607a4971c7e3c0026dc65f8e48fe2824f9553840bb46f3b389ae"
+url = "https://github.com/WebAssembly/wasi-http/archive/main.tar.gz"
+sha256 = "192e0a0418776415401297ff11151972d5f78500785ad427ff0ac3bbdd298281"
+sha512 = "387915dad450e61e73b1eae82b1702fbae6e8bdc7a92165a195edd7a3eb1ac25f4ea1fc230d69e860fec8e2c05bc5be8937077966c928c9f179ee35a964d276f"
 
 [io]
 url = "https://github.com/rvolosatovs/wasi-io/archive/v0.1.0.tar.gz"
@@ -14,11 +14,11 @@ sha256 = "f378a2b6a36af096528ec5e7031da474990cecaec1949c663befc5066d719f6f"
 sha512 = "ba09307b12f5428c3058d878001c9fb15df21933c6203328f785d5009a4fc0cf304950271590d4146305a2d8b8988595f396d955961168cb6bfa7ea9af1cc362"
 
 [poll]
-url = "https://github.com/WebAssembly/wasi-poll/archive/3ff76670b0d43bc7c8a224c2e65880a963416835.tar.gz"
+url = "https://github.com/WebAssembly/wasi-poll/archive/main.tar.gz"
 sha256 = "065422b0ea6ccb2a9facc6b87b902eef110c53d76fc31f341a6bc8d0b0285b6a"
 sha512 = "19a55cd3072a19ae6a1774723a4962e7a155a5ce89a27175e8c76020efb4d00bc92ebb78427d92bcb8effd4f0d03ebf0a0daa747ecd981b8d31d5abc2ad86423"
 
 [random]
-url = "https://github.com/WebAssembly/wasi-random/archive/28970c50c3797c0087fa75a15e88bfa39b91e0a0.tar.gz"
+url = "https://github.com/WebAssembly/wasi-random/archive/main.tar.gz"
 sha256 = "79b6417bb1ab3c82c241c56021e717f258e2a0b3ab94db93907ca11d7f92ed66"
 sha512 = "1e657ac56420e65bde75eabea920a605a0ff4adc6f2ba8b7cf1c37a603710449bc1a29568dda2b61c04ae9889d2b1a82b9935d4b9d573eb48a83e0ecf9cad591"

--- a/examples/github/wit/deps.toml
+++ b/examples/github/wit/deps.toml
@@ -1,8 +1,12 @@
-http = "https://github.com/WebAssembly/wasi-http/archive/6c6855a7329fb040a48ecdbad1765be8e694416c.tar.gz"
-io = "https://github.com/rvolosatovs/wasi-io/archive/v0.1.0.tar.gz" # this fork renames `streams` interface for compatiblity with wasi-snapshot-preview1
-poll = "https://github.com/WebAssembly/wasi-poll/archive/3ff76670b0d43bc7c8a224c2e65880a963416835.tar.gz"
-random = "https://github.com/WebAssembly/wasi-random/archive/28970c50c3797c0087fa75a15e88bfa39b91e0a0.tar.gz"
+# Use `depit update` to pull in latest changes from "dynamic" branch references
+http = "https://github.com/WebAssembly/wasi-http/archive/main.tar.gz"
+poll = "https://github.com/WebAssembly/wasi-poll/archive/main.tar.gz"
+random = "https://github.com/WebAssembly/wasi-random/archive/main.tar.gz"
 
+# Pin to a tag
+io = "https://github.com/rvolosatovs/wasi-io/archive/v0.1.0.tar.gz" # this fork renames `streams` interface for compatiblity with wasi-snapshot-preview1
+
+# Pin a dependency to a particular revision and source digests
 [logging]
 url = "https://github.com/WebAssembly/wasi-logging/archive/d106e59b25297d0496e6a5d221ad090e19c3aaa3.tar.gz"
 sha256 = "4bb4aeab99e7323b30d107aab78e88b2265c1598cc438bc5fbc0d16bb63e798f"

--- a/examples/github/wit/deps/http/types.wit
+++ b/examples/github/wit/deps/http/types.wit
@@ -78,18 +78,16 @@ default interface types {
   drop-incoming-request: func(request: incoming-request)
   drop-outgoing-request: func(request: outgoing-request)
   incoming-request-method: func(request: incoming-request) -> method
-  incoming-request-path: func(request: incoming-request) -> string
-  incoming-request-query: func(request: incoming-request) -> string
+  incoming-request-path-with-query: func(request: incoming-request) -> option<string>
   incoming-request-scheme: func(request: incoming-request) -> option<scheme>
-  incoming-request-authority: func(request: incoming-request) -> string
+  incoming-request-authority: func(request: incoming-request) -> option<string>
   incoming-request-headers: func(request: incoming-request) -> headers
   incoming-request-consume: func(request: incoming-request) -> result<incoming-stream>
   new-outgoing-request: func(
     method: method,
-    path: string,
-    query: string,
+    path-with-query: option<string>,
     scheme: option<scheme>,
-    authority: string,
+    authority: option<string>,
     headers: headers
   ) -> outgoing-request
   outgoing-request-write: func(request: outgoing-request) -> result<outgoing-stream>

--- a/src/bin/depit/main.rs
+++ b/src/bin/depit/main.rs
@@ -37,6 +37,12 @@ enum Command {
         #[arg(short, long)]
         package: Vec<Identifier>,
     },
+    /// Update dependencies
+    Update {
+        /// Optional list of packages to update
+        #[arg(short, long)]
+        package: Vec<Identifier>,
+    },
     /// Write a deterministic tar containing the `wit` subdirectory for a package to stdout
     Tar {
         /// Package to archive
@@ -79,6 +85,11 @@ async fn main() -> anyhow::Result<()> {
             .map(|_| ()),
         Some(Command::Lock { package }) => {
             depit::lock_path(None, manifest_path, lock_path, deps_path, &package)
+                .await
+                .map(|_| ())
+        }
+        Some(Command::Update { package }) => {
+            depit::update_path(None, manifest_path, lock_path, deps_path, &package)
                 .await
                 .map(|_| ())
         }


### PR DESCRIPTION
Add support for `depit update`, which allows for "dynamic reference" use case like was done in https://github.com/WebAssembly/wasi-http/pull/23

This allows, for example, to pin to "dynamic" branches and periodically invoke `depit update` to pull in latest changes updating the local cache as a side effect. I really like how this aligns with e.g. `nix flake update`.

See changes in `examples/github` for an example usage

cc @lukewagner